### PR TITLE
Feature/cron expression cconfiguration externalized rule

### DIFF
--- a/AVIOCustomRuleConfiguration.groovy
+++ b/AVIOCustomRuleConfiguration.groovy
@@ -46,6 +46,8 @@ class AVIOCustomRuleConfiguration {
 		rules.addRule(new PropertyExistsRule('db.user', ENVIRONMENTS))
 		rules.addRule(new PropertyFileNamingRule(ENVIRONMENTS))
 		rules.addRule(new PropertyFilePropertyCountRule(ENVIRONMENTS))
+		
+		rules.addRule(new CronExpressionConfigurableRule())
 
 		return rules
 	}

--- a/src/main/groovy/com/avioconsulting/mule/linter/model/configuration/MuleComponent.groovy
+++ b/src/main/groovy/com/avioconsulting/mule/linter/model/configuration/MuleComponent.groovy
@@ -23,6 +23,17 @@ class MuleComponent {
         this.file = file
     }
 
+    Boolean isExternalized(String value) {
+        if (value != null) {
+            return value.startsWith('Mule::p(')
+                    || value.startsWith('p(')
+                    || value.startsWith('${')
+                    || value.startsWith('#[')
+        }
+        else {
+            return false
+        }
+    }
     Boolean hasAttributeValue(String name) {
         return attributes.get(name)?.length() > 0
     }

--- a/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRule.groovy
+++ b/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRule.groovy
@@ -7,8 +7,8 @@ import com.avioconsulting.mule.linter.model.rule.RuleSeverity
 import com.avioconsulting.mule.linter.model.rule.RuleViolation
 
 class CronExpressionConfigurableRule extends Rule {
-    static final String RULE_ID = 'CRON_EXPRESSION_CONFIGURABLE'
-    static final String RULE_NAME = 'Cron Expression is Configurable in a property file '
+    static final String RULE_ID = 'CRON_EXPRESSION_EXTERNALIZED'
+    static final String RULE_NAME = 'Cron Expression is configured in a property file '
     static final String CRON_EXPRESSION_HARD_CODED = 'CRON Expression should be configured in a property file, currently it is hardcoded in the file :  '
 
     CronExpressionConfigurableRule() {
@@ -17,19 +17,13 @@ class CronExpressionConfigurableRule extends Rule {
         this.severity = RuleSeverity.MAJOR
 
     }
-
     @Override
     List<RuleViolation> execute(Application app) {
         List<RuleViolation> violations = []
-        //Auto discovery configuration would be check only in Global Config file
-
-// Iterate over each configuration file using Application Model
+        if(app.configurationFiles!=null && app.configurationFiles.size() >0){
         app.configurationFiles.each {
-                // Assign the file to a temporary variable configFile
             configFile ->
-                // Get all configurations within non Global Mule Configuration file
                 List<MuleComponent> flowLevelComponentList = configFile.findNonGlobalConfigs()
-                // If any components exist in the Mule Configuration File
                 if (flowLevelComponentList!=null && flowLevelComponentList.size() > 0) {
                     flowLevelComponentList.each {
                         firstLevelComponent ->
@@ -40,36 +34,23 @@ class CronExpressionConfigurableRule extends Rule {
                                             secondLevelComponent.getChildren().each {
                                                 thirdLevelComponent ->
                                                     if (thirdLevelComponent.getChildren()!=null && thirdLevelComponent.getChildren().size() > 0) {
-
                                                         thirdLevelComponent.getChildren().each {
                                                             fourthLevelComponent ->
                                                                 if (fourthLevelComponent.componentName!=null && fourthLevelComponent.componentName.equalsIgnoreCase("cron")) {
-                                                                     if(fourthLevelComponent.getAttributeValue('expression')!=null && !(fourthLevelComponent.getAttributeValue('expression').startsWith('Mule::p(')
-                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('p(')
-                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('${')
-                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('#[') )){
-
-                                                                        violations.add(new RuleViolation(this, configFile.file.path, fourthLevelComponent.lineNumber, CRON_EXPRESSION_HARD_CODED + configFile.file.name ))
-
+                                                                     if(!fourthLevelComponent.isExternalized(fourthLevelComponent.getAttributeValue('expression'))){
+                                                                        violations.add(new RuleViolation(this, configFile.file.path, fourthLevelComponent.lineNumber, CRON_EXPRESSION_HARD_CODED + configFile.file.name+". The hard coded cron expression is : "+ fourthLevelComponent.getAttributeValue('expression') ))
                                                                     }
-
                                                                 }
-
                                                         }
                                                     }
                                             }
-
                                         }
-
                                 }
                             }
                     }
-
                 }
-
         }
-
-
+        }
         return violations
     }
 }

--- a/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRule.groovy
+++ b/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRule.groovy
@@ -1,0 +1,75 @@
+package com.avioconsulting.mule.linter.rule.configuration
+
+import com.avioconsulting.mule.linter.model.Application
+import com.avioconsulting.mule.linter.model.configuration.MuleComponent
+import com.avioconsulting.mule.linter.model.rule.Rule
+import com.avioconsulting.mule.linter.model.rule.RuleSeverity
+import com.avioconsulting.mule.linter.model.rule.RuleViolation
+
+class CronExpressionConfigurableRule extends Rule {
+    static final String RULE_ID = 'CRON_EXPRESSION_CONFIGURABLE'
+    static final String RULE_NAME = 'Cron Expression is Configurable in a property file '
+    static final String CRON_EXPRESSION_HARD_CODED = 'CRON Expression should be configured in a property file, currently it is hardcoded in the file :  '
+
+    CronExpressionConfigurableRule() {
+        this.ruleId = RULE_ID
+        this.ruleName = RULE_NAME
+        this.severity = RuleSeverity.MAJOR
+
+    }
+
+    @Override
+    List<RuleViolation> execute(Application app) {
+        List<RuleViolation> violations = []
+        //Auto discovery configuration would be check only in Global Config file
+
+// Iterate over each configuration file using Application Model
+        app.configurationFiles.each {
+                // Assign the file to a temporary variable configFile
+            configFile ->
+                // Get all configurations within non Global Mule Configuration file
+                List<MuleComponent> flowLevelComponentList = configFile.findNonGlobalConfigs()
+                // If any components exist in the Mule Configuration File
+                if (flowLevelComponentList!=null && flowLevelComponentList.size() > 0) {
+                    flowLevelComponentList.each {
+                        firstLevelComponent ->
+                            if (firstLevelComponent.getChildren()!=null && firstLevelComponent.getChildren().size() > 0) {
+                                firstLevelComponent.getChildren().each {
+                                    secondLevelComponent ->
+                                        if (secondLevelComponent.getChildren()!=null && secondLevelComponent.getChildren().size() > 0) {
+                                            secondLevelComponent.getChildren().each {
+                                                thirdLevelComponent ->
+                                                    if (thirdLevelComponent.getChildren()!=null && thirdLevelComponent.getChildren().size() > 0) {
+
+                                                        thirdLevelComponent.getChildren().each {
+                                                            fourthLevelComponent ->
+                                                                if (fourthLevelComponent.componentName!=null && fourthLevelComponent.componentName.equalsIgnoreCase("cron")) {
+                                                                     if(fourthLevelComponent.getAttributeValue('expression')!=null && !(fourthLevelComponent.getAttributeValue('expression').startsWith('Mule::p(')
+                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('p(')
+                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('${')
+                                                                            || fourthLevelComponent.getAttributeValue('expression').startsWith('#[') )){
+
+                                                                        violations.add(new RuleViolation(this, configFile.file.path, fourthLevelComponent.lineNumber, CRON_EXPRESSION_HARD_CODED + configFile.file.name ))
+
+                                                                    }
+
+                                                                }
+
+                                                        }
+                                                    }
+                                            }
+
+                                        }
+
+                                }
+                            }
+                    }
+
+                }
+
+        }
+
+
+        return violations
+    }
+}

--- a/src/test/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRuleTest.groovy
+++ b/src/test/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRuleTest.groovy
@@ -50,10 +50,10 @@ class CronExpressionConfigurableRuleTest extends Specification{
 
         then:
         violations.size() == 2
-        violations[0].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"
+        violations[0].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"+". The hard coded cron expression is : * * 10 * * * *"
         violations[0].lineNumber == 12
 
-        violations[1].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"
+        violations[1].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"+". The hard coded cron expression is : * * 12 * * * *"
         violations[1].lineNumber == 84
     }
 

--- a/src/test/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRuleTest.groovy
+++ b/src/test/groovy/com/avioconsulting/mule/linter/rule/configuration/CronExpressionConfigurableRuleTest.groovy
@@ -1,0 +1,245 @@
+package com.avioconsulting.mule.linter.rule.configuration
+
+import com.avioconsulting.mule.linter.TestApplication
+import com.avioconsulting.mule.linter.model.Application
+import com.avioconsulting.mule.linter.model.rule.Rule
+import com.avioconsulting.mule.linter.model.rule.RuleViolation
+import com.avioconsulting.mule.linter.rule.configuration.CronExpressionConfigurableRule
+import spock.lang.Specification
+
+@SuppressWarnings(['MethodName', 'MethodReturnTypeRequired', 'GStringExpressionWithinString',
+        'StaticFieldsBeforeInstanceFields'])
+
+class CronExpressionConfigurableRuleTest extends Specification{
+
+    private final TestApplication testApp = new TestApplication()
+    private Application app
+
+    def setup() {
+        testApp.initialize()
+        testApp.addPom()
+        testApp.addConfig()
+    }
+
+    def cleanup() {
+        testApp.remove()
+    }
+
+    def 'Cron Expression correctly configured within the property files '() {
+        given:
+        testApp.addFile('src/main/mule/sales-orders-csv-impl.xml', GOOD_CONFIG_1)
+        Rule rule = new CronExpressionConfigurableRule()
+
+        when:
+        Application app = new Application(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        violations.size() == 0
+
+    }
+
+    def 'Cron Expression Hardcoded in the Mule Configuration file'() {
+        given:
+        testApp.addFile('src/main/mule/sales-orders-csv-impl.xml', BAD_CONFIG_1)
+        Rule rule = new CronExpressionConfigurableRule()
+
+        when:
+        Application app = new Application(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        violations.size() == 2
+        violations[0].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"
+        violations[0].lineNumber == 12
+
+        violations[1].message == CronExpressionConfigurableRule.CRON_EXPRESSION_HARD_CODED+"sales-orders-csv-impl.xml"
+        violations[1].lineNumber == 84
+    }
+
+    private static final String GOOD_CONFIG_1 = '''<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:avio-core="http://www.mulesoft.org/schema/mule/avio-core" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+\txmlns:file="http://www.mulesoft.org/schema/mule/file"
+\txmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/avio-core http://www.mulesoft.org/schema/mule/avio-core/current/mule-avio-core.xsd">
+\t<flow name="sales-orders-csv-impl" doc:id="eaafe27a-7c53-40fb-9fef-c34f17bf43a1" >
+\t\t<file:listener doc:name="On New or Updated File" doc:id="c590b952-2ac4-4cdc-8f39-df8d9d3d7490" config-ref="csv-file-config" directory="/Users/swapna.venugopal/Documents/Artifacts/AVIO/Training/git-bc-repos/phase3a/bc10-swapna-venugopal-repo/sv-sales-order-api/src/main/resources/examples/csv" moveToDirectory="/Users/swapna.venugopal/Documents/Artifacts/AVIO/Training/git-bc-repos/phase3a/bc10-swapna-venugopal-repo/sv-sales-order-api/src/main/resources/examples/csvarchive">
+\t\t\t<scheduling-strategy >
+\t\t\t\t<cron expression="${cron.expression}" />
+\t\t\t</scheduling-strategy>
+\t\t\t<file:matcher filenamePattern="*.csv"/>
+\t\t</file:listener>
+\t\t<avio-core:custom-logger doc:name="START" doc:id="a2cc2e57-9754-4551-984f-66e76644f738" config-ref="avio-core-config" correlation_id="#[attributes.fileName]" message="sales-order-csv-flow" tracePoint="START" category="${logcat}" logLocationInfo="true" />
+\t\t<ee:transform doc:name="payload" doc:id="1b3ca8ba-7ec7-423b-a693-5f6cfa8c4a5c" >
+\t\t\t<ee:message >
+\t\t\t\t<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+var orders = payload
+---
+
+(orders groupBy ((item, index) -> item.salesOrderId)) pluck ((value, key, index) -> value) 
+map (salesOrder, index) -> {
+    customerId :    salesOrder[index].customerId,
+    customerName :  salesOrder[index].customerName,
+    salesOrderId :   salesOrder[index].salesOrderId,
+    lineItems : \tsalesOrder map (item) -> {
+\t\tlineItemNumber : item.itemNumber,
+        quantity : \titem.quantity,
+        lineItemType : item.itemType,
+        price :\titem.price,
+        itemDescription : \titem.itemDescription
+    }
+    
+}]]></ee:set-payload>
+\t\t\t</ee:message>
+\t\t\t<ee:variables >
+\t\t\t</ee:variables>
+\t\t</ee:transform>
+\t\t<foreach doc:name="for-each-sales-order" doc:id="4ba0c498-1766-48a4-9650-bfbca603fc09" >
+\t\t\t<try doc:name="Try" doc:id="0e846dae-0429-4fd8-93e3-ad094bbed58d" >
+\t\t\t\t<ee:transform doc:name="salesOrderAttributes" doc:id="b6e8d8a1-de3d-4179-b35f-a061ee8cb715">
+\t\t\t\t<ee:message>
+\t\t\t\t\t<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+\t\t\t\t</ee:message>
+\t\t\t\t<ee:variables>
+\t\t\t\t\t\t<ee:set-variable variableName="salesOrderAttributes"><![CDATA[%dw 2.0
+output application/java
+---
+{
+\tsalesOrderStatus:
+\t{
+\t\tsalesOrderId: payload.salesOrderId,
+\t\tstatus: "CONFIRMED"
+\t},
+\tqueueName: p('vm.inputQ')
+}]]></ee:set-variable>
+\t\t\t\t</ee:variables>
+\t\t\t</ee:transform>
+\t\t\t\t<flow-ref doc:name="sr-publish-vm-queue" doc:id="30c62eb1-8669-456c-9e8f-845342e1a696" name="sr-publish-vm-queue" />
+\t\t\t\t<flow-ref doc:name="sr-objectstore-sales-order-status-update" doc:id="21c3e1dd-a38f-42bf-b238-d88a0db1a558" name="sr-objectstore-sales-order-status-update" />
+\t\t\t\t<error-handler >
+\t\t\t\t\t<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="c88f283d-02dd-475a-8dfb-09d5e0ccd762" type="ANY">
+\t\t\t\t\t\t<avio-core:custom-logger doc:name="ERROR-csv-processing" doc:id="8e23c793-05ca-48a9-9600-2c6f29a241a4" config-ref="avio-core-config" correlation_id="#[payload.salesOrderId]" message="ERROR while processing Sales Order Payload from CSV file" level="ERROR" tracePoint="EXCEPTION" category="${logcat}" status_code="500" type="#[error.errorType.identifier as String]" detail="#[error.description as String]" logLocationInfo="true" />
+\t\t\t\t\t</on-error-continue>
+\t\t\t\t</error-handler>
+\t\t\t</try>
+\t\t</foreach>
+\t\t<avio-core:custom-logger doc:name="END" doc:id="3470f167-6de9-43a6-bf7f-da431139b96d" config-ref="avio-core-config" message="sales-order-csv-flow" tracePoint="END" category="${logcat}" logLocationInfo="true" correlation_id="#[attributes.fileName]"/>
+\t\t<error-handler >
+\t\t\t<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="87fcf9a0-8d6e-4aba-9fe9-a7a637c19efe" type="ANY">
+\t\t\t\t<avio-core:custom-logger doc:name="ERROR CATCH ALL" doc:id="51881ce7-a3c6-428b-94fa-3abeafbeab03" config-ref="avio-core-config" correlation_id="#[payload.salesOrderId]" message="ERROR while processing Sales Order Payload from CSV file" level="ERROR" tracePoint="EXCEPTION" category="${logcat}" status_code="500" type="#[error.errorType.identifier as String]" detail="#[error.description as String]" logLocationInfo="true" />
+\t\t\t</on-error-continue>
+\t\t</error-handler>
+\t</flow>
+\t<flow name="sales-orders-csv-implFlow" doc:id="b0c8f50f-11b2-4596-9dc6-cb0e8835814b" >
+\t\t<scheduler doc:name="Scheduler Flow" doc:id="404bdd5b-ba0f-4f86-9687-8d047a264175" >
+\t\t\t<scheduling-strategy >
+\t\t\t\t<cron expression="${cron.expression}" timeZone="CST"/>
+\t\t\t</scheduling-strategy>
+\t\t</scheduler>
+\t</flow>
+</mule>
+
+
+'''
+
+
+    private static final String BAD_CONFIG_1 = '''<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:avio-core="http://www.mulesoft.org/schema/mule/avio-core" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+\txmlns:file="http://www.mulesoft.org/schema/mule/file"
+\txmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/avio-core http://www.mulesoft.org/schema/mule/avio-core/current/mule-avio-core.xsd">
+\t<flow name="sales-orders-csv-impl" doc:id="eaafe27a-7c53-40fb-9fef-c34f17bf43a1" >
+\t\t<file:listener doc:name="On New or Updated File" doc:id="c590b952-2ac4-4cdc-8f39-df8d9d3d7490" config-ref="csv-file-config" directory="/Users/swapna.venugopal/Documents/Artifacts/AVIO/Training/git-bc-repos/phase3a/bc10-swapna-venugopal-repo/sv-sales-order-api/src/main/resources/examples/csv" moveToDirectory="/Users/swapna.venugopal/Documents/Artifacts/AVIO/Training/git-bc-repos/phase3a/bc10-swapna-venugopal-repo/sv-sales-order-api/src/main/resources/examples/csvarchive">
+\t\t\t<scheduling-strategy >
+\t\t\t\t<cron expression="* * 10 * * * *" />
+\t\t\t</scheduling-strategy>
+\t\t\t<file:matcher filenamePattern="*.csv"/>
+\t\t</file:listener>
+\t\t<avio-core:custom-logger doc:name="START" doc:id="a2cc2e57-9754-4551-984f-66e76644f738" config-ref="avio-core-config" correlation_id="#[attributes.fileName]" message="sales-order-csv-flow" tracePoint="START" category="${logcat}" logLocationInfo="true" />
+\t\t<ee:transform doc:name="payload" doc:id="1b3ca8ba-7ec7-423b-a693-5f6cfa8c4a5c" >
+\t\t\t<ee:message >
+\t\t\t\t<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+var orders = payload
+---
+
+(orders groupBy ((item, index) -> item.salesOrderId)) pluck ((value, key, index) -> value) 
+map (salesOrder, index) -> {
+    customerId :    salesOrder[index].customerId,
+    customerName :  salesOrder[index].customerName,
+    salesOrderId :   salesOrder[index].salesOrderId,
+    lineItems : \tsalesOrder map (item) -> {
+\t\tlineItemNumber : item.itemNumber,
+        quantity : \titem.quantity,
+        lineItemType : item.itemType,
+        price :\titem.price,
+        itemDescription : \titem.itemDescription
+    }
+    
+}]]></ee:set-payload>
+\t\t\t</ee:message>
+\t\t\t<ee:variables >
+\t\t\t</ee:variables>
+\t\t</ee:transform>
+\t\t<foreach doc:name="for-each-sales-order" doc:id="4ba0c498-1766-48a4-9650-bfbca603fc09" >
+\t\t\t<try doc:name="Try" doc:id="0e846dae-0429-4fd8-93e3-ad094bbed58d" >
+\t\t\t\t<ee:transform doc:name="salesOrderAttributes" doc:id="b6e8d8a1-de3d-4179-b35f-a061ee8cb715">
+\t\t\t\t<ee:message>
+\t\t\t\t\t<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+\t\t\t\t</ee:message>
+\t\t\t\t<ee:variables>
+\t\t\t\t\t\t<ee:set-variable variableName="salesOrderAttributes"><![CDATA[%dw 2.0
+output application/java
+---
+{
+\tsalesOrderStatus:
+\t{
+\t\tsalesOrderId: payload.salesOrderId,
+\t\tstatus: "CONFIRMED"
+\t},
+\tqueueName: p('vm.inputQ')
+}]]></ee:set-variable>
+\t\t\t\t</ee:variables>
+\t\t\t</ee:transform>
+\t\t\t\t<flow-ref doc:name="sr-publish-vm-queue" doc:id="30c62eb1-8669-456c-9e8f-845342e1a696" name="sr-publish-vm-queue" />
+\t\t\t\t<flow-ref doc:name="sr-objectstore-sales-order-status-update" doc:id="21c3e1dd-a38f-42bf-b238-d88a0db1a558" name="sr-objectstore-sales-order-status-update" />
+\t\t\t\t<error-handler >
+\t\t\t\t\t<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="c88f283d-02dd-475a-8dfb-09d5e0ccd762" type="ANY">
+\t\t\t\t\t\t<avio-core:custom-logger doc:name="ERROR-csv-processing" doc:id="8e23c793-05ca-48a9-9600-2c6f29a241a4" config-ref="avio-core-config" correlation_id="#[payload.salesOrderId]" message="ERROR while processing Sales Order Payload from CSV file" level="ERROR" tracePoint="EXCEPTION" category="${logcat}" status_code="500" type="#[error.errorType.identifier as String]" detail="#[error.description as String]" logLocationInfo="true" />
+\t\t\t\t\t</on-error-continue>
+\t\t\t\t</error-handler>
+\t\t\t</try>
+\t\t</foreach>
+\t\t<avio-core:custom-logger doc:name="END" doc:id="3470f167-6de9-43a6-bf7f-da431139b96d" config-ref="avio-core-config" message="sales-order-csv-flow" tracePoint="END" category="${logcat}" logLocationInfo="true" correlation_id="#[attributes.fileName]"/>
+\t\t<error-handler >
+\t\t\t<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="87fcf9a0-8d6e-4aba-9fe9-a7a637c19efe" type="ANY">
+\t\t\t\t<avio-core:custom-logger doc:name="ERROR CATCH ALL" doc:id="51881ce7-a3c6-428b-94fa-3abeafbeab03" config-ref="avio-core-config" correlation_id="#[payload.salesOrderId]" message="ERROR while processing Sales Order Payload from CSV file" level="ERROR" tracePoint="EXCEPTION" category="${logcat}" status_code="500" type="#[error.errorType.identifier as String]" detail="#[error.description as String]" logLocationInfo="true" />
+\t\t\t</on-error-continue>
+\t\t</error-handler>
+\t</flow>
+\t<flow name="sales-orders-csv-implFlow" doc:id="b0c8f50f-11b2-4596-9dc6-cb0e8835814b" >
+\t\t<scheduler doc:name="Scheduler Flow" doc:id="404bdd5b-ba0f-4f86-9687-8d047a264175" >
+\t\t\t<scheduling-strategy >
+\t\t\t\t<cron expression="* * 12 * * * *" timeZone="CST"/>
+\t\t\t</scheduling-strategy>
+\t\t</scheduler>
+\t</flow>
+</mule>
+
+
+'''
+
+}


### PR DESCRIPTION
Cron Expressions are used in most implementations using Scheduled/Batch based integration for its flexibility. 
The Cron Expression should not be hardcoded in Mule Configuration file and should be externalized in a property file
The Rule Ensures the following,
- Cron clauses in flows should not have hardcoded configuration. 
- Cron Expressions should be implemented in property files and referenced in xml configuration files.