### PR TITLE
Add GDSL Generator task

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ Generated Distribution and install in local -
 
 `./gradlew installDist`
 
-If rules are modified, regenerate GDSL file (before assembling) - 
-
-`./gradlew generateGDSL`
-
-
 
 ## Rule Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Unzip/Untar the distribution. You can run the CLI from expanded files -
 You may move expanded distribution folder to other persistent location and add it on OS PATH, 
 and then run cli from anywhere on the system.
 
+## Build
+To build the project run - 
+
+`./gradlew build`
+
+Generated Distribution and install in local - 
+
+`./gradlew installDist`
+
+If rules are modified, regenerate GDSL file (before assembling) - 
+
+`./gradlew generateGDSL`
+
+
 
 ## Rule Configuration
 

--- a/mule-linter-core/build.gradle
+++ b/mule-linter-core/build.gradle
@@ -44,6 +44,7 @@ task generateGDSL (type: JavaExec) {
     classpath += sourceSets.main.runtimeClasspath
 }
 
+jar.dependsOn(generateGDSL)
 
 publishing {
     publications {

--- a/mule-linter-core/build.gradle
+++ b/mule-linter-core/build.gradle
@@ -1,3 +1,4 @@
+
 plugins {
     id 'codenarc'
 }
@@ -21,6 +22,26 @@ test {
 codenarc {
     configFile = file("${rootProject.projectDir}/config/code-quality-config/codenarc/codenarc.xml")
     ignoreFailures = true
+}
+
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:unchecked"
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:unchecked"
+}
+
+task generateGDSL (type: JavaExec) {
+    //Generates GDSL file using `GDSLGenerator.groovy`.
+    // Generated file is added in src/main/resources.
+    // Run `./gradlew generateGDSL`
+    main = 'GDSLGeneratorScript'
+    classpath += sourceSets.main.compileClasspath // Needed for Velocity compiletime
+    classpath += sourceSets.main.runtimeClasspath
 }
 
 

--- a/mule-linter-core/mule-linter-core.gdsl.vm
+++ b/mule-linter-core/mule-linter-core.gdsl.vm
@@ -1,0 +1,66 @@
+#macro(methodParam $param $type)
+method name: '$param',
+        params: [
+            $param: $type
+        ]
+#end
+#macro(stringParam $param)
+    #methodParam($param 'String.name')
+#end
+#macro(boolParam $param)
+    #methodParam($param 'Boolean.name')
+#end
+#macro(mapParam $param)
+    #methodParam($param 'Map.name')
+#end
+#macro(closureParam $param)
+        method name: '$param',
+                params: [
+                        closure: Closure.name
+                ]
+#end
+#macro(prop $propName)
+            property name: '$propName',
+                    type: String.name
+#end
+#macro(typedProp $propName $propType)
+            property name: '$propName',
+                    type: '$propType'
+#end
+
+def linterCtx = context(scriptScope: 'muleLinter.groovy')
+contributor([linterCtx]) {
+    method name: 'mule_linter',
+            params: [
+                    closure: Closure.name
+            ]
+}
+
+def closureScopeContext = context(scope: closureScope())
+contributor([closureScopeContext]) {
+    def call = enclosingCall('mule_linter')
+    if(call) {
+        method name: 'rules',
+                params: [
+                        closure: Closure.name
+                ]
+    }
+    call = enclosingCall("rules")
+    if(call) {
+        #foreach($ruleId in $ruleIds)
+            #closureParam($ruleId)
+        #end
+    }
+    #set($paramSuffix = '-param')
+    #foreach($ruleId in $ruleIds)
+        #set( $ruleKey= $ruleId+$paramSuffix )
+        call = enclosingCall("$ruleId")
+        if(call) {
+            #foreach($param in $rules.get($ruleId).params)
+                #typedProp($param.v1, $param.v2)
+            #end
+        }
+
+    #end
+
+}

--- a/mule-linter-core/src/main/groovy/GDSLGeneratorScript.groovy
+++ b/mule-linter-core/src/main/groovy/GDSLGeneratorScript.groovy
@@ -1,0 +1,6 @@
+
+println 'Generating GDSL file'
+def outputPath = "./src/main/resources/mule-linter-core.gdsl"
+def templateFileName = "./mule-linter-core.gdsl.vm"
+com.avioconsulting.mule.linter.dsl.GDSLGenerator gdslGenerator = new com.avioconsulting.mule.linter.dsl.GDSLGenerator();
+gdslGenerator.generate(templateFileName, outputPath )

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/dsl/GDSLGenerator.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/dsl/GDSLGenerator.groovy
@@ -1,0 +1,83 @@
+package com.avioconsulting.mule.linter.dsl
+
+import com.avioconsulting.mule.linter.model.rule.Param
+import com.avioconsulting.mule.linter.model.rule.Rule
+import org.apache.velocity.Template
+import org.apache.velocity.VelocityContext
+import org.apache.velocity.app.VelocityEngine
+import org.reflections.Reflections
+import org.reflections.scanners.Scanners
+import org.reflections.util.ConfigurationBuilder
+
+class GDSLGenerator {
+
+
+    class RuleMeta {
+        String ruleId
+        List<Tuple2> params = new ArrayList<>()
+        Class<? extends Rule> ruleClass
+        RuleMeta(ruleClass){
+            this.ruleClass = ruleClass
+        }
+    }
+
+    def generate(String templatePath, String outputPath) {
+
+        println 'Generating GDSL file'
+        VelocityEngine engine = new VelocityEngine();
+        VelocityContext context = new VelocityContext();
+        String templateFileName = templatePath
+        Template template = engine.getTemplate(templateFileName)
+        Map<String, RuleMeta> rulesMap = getRulesMap(null)
+        context.put("rules", rulesMap)
+        context.put("ruleIds", rulesMap.keySet())
+        try {
+            def file = new File(outputPath)
+            OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file))
+            template.merge(context, writer);
+            writer.close();
+            println 'Generated GDSL at ' + file.path
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    Map<String, RuleMeta> getRulesMap(String packagePrefix) {
+        def Map<String, RuleMeta> rulesMap = [:]
+//This loads all Rule classes shipped with core.
+//TODO: Find a way to load all classes from external library that can have different package.
+        Reflections rf = new Reflections(new ConfigurationBuilder()
+                .forPackages("com.", "org.", "io.")
+                .setExpandSuperTypes(false)
+                .addScanners(Scanners.values()))
+
+        def rules = rf.getSubTypesOf(Rule.class)
+//Look for field named RULE_ID
+        rules.each { rule -> {
+            rulesMap.put(rule.RULE_ID, new RuleMeta(rule))
+        }}
+
+
+        rf.getFieldsAnnotatedWith(Param.class).each { field -> {
+            def aValue = field.getAnnotation(Param.class).value()
+            def ruleId = field.declaringClass.RULE_ID
+            rulesMap.get(ruleId).params.add(new Tuple2(aValue, field.genericType.typeName))
+        }}
+
+
+        rf.getConstructorsWithParameter(Param.class).each { cs -> {
+            cs.parameters.each { p ->
+                if(p.isAnnotationPresent(Param.class)) {
+                    def annotation = p.getAnnotation(Param.class)
+                    def aValue = annotation.value()
+
+                    def ruleId = cs.declaringClass.RULE_ID
+                    rulesMap.get(ruleId).params.add(new Tuple2(aValue, p.getParameterizedType().typeName))
+                }
+
+            }
+        }}
+
+        return rulesMap
+    }
+}

--- a/mule-linter-core/src/main/resources/mule-linter-core.gdsl
+++ b/mule-linter-core/src/main/resources/mule-linter-core.gdsl
@@ -1,0 +1,421 @@
+
+def linterCtx = context(scriptScope: 'muleLinter.groovy')
+contributor([linterCtx]) {
+    method name: 'mule_linter',
+            params: [
+                    closure: Closure.name
+            ]
+}
+
+def closureScopeContext = context(scope: closureScope())
+contributor([closureScopeContext]) {
+    def call = enclosingCall('mule_linter')
+    if(call) {
+        method name: 'rules',
+                params: [
+                        closure: Closure.name
+                ]
+    }
+    call = enclosingCall("rules")
+    if(call) {
+        method name: 'CONFIG_FILE_NAMING',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'PROPERTY_FILE_COUNT_MISMATCH',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'POM_PLUGIN_ATTRIBUTE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'UNUSED_FLOW',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'FLOW_SUBFLOW_NAMING',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'GIT_IGNORE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MULE_ARTIFACT_SECURE_PROPERTIES',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'DISPLAY_NAME',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'GLOBAL_CONFIG_NO_FLOWS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'COMPONENT_COUNT',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'LOGGER_ATTRIBUTES_RULE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MULE_ARTIFACT_MIN_MULE_VERSION',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'COMMENTED_CODE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'CONFIG_PLACEHOLDER',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'POM_EXISTS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'ENCRYPTED_VALUE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MULE_CONFIG_SIZE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'PROPERTY_FILE_NAMING',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'LOGGER_MESSAGE_CONTENTS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'HOSTNAME_PROPERTY',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'README',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'ON_ERROR_LOG_EXCEPTION',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'API_CONSOLE_DISABLED',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MAVEN_PROPERTY',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'AZURE_PIPELINES_EXISTS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'JENKINS_EXISTS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'COMPONENT_ATTRIBUTE_VALUE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'EXCESSIVE_LOGGERS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MUNIT_MAVEN_PLUGIN_ATTRIBUTES',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'POM_DEPENDENCY_VERSION',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'PROPERTY_EXISTS',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'GLOBAL_CONFIG',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MUNIT_PLUGIN_VERSION',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MULE_MAVEN_PLUGIN',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'UNTIL_SUCCESSFUL',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'LOGGER_CATEGORY_HASVALUE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'LOGGER_MESSAGE_HASVALUE',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MULE_RUNTIME',
+                params: [
+                        closure: Closure.name
+                ]
+        method name: 'MUNIT_VERSION',
+                params: [
+                        closure: Closure.name
+                ]
+    }
+        call = enclosingCall("CONFIG_FILE_NAMING")
+        if(call) {
+            property name: 'format',
+                    type: 'com.avioconsulting.mule.linter.model.CaseNaming$CaseFormat'
+        }
+
+        call = enclosingCall("PROPERTY_FILE_COUNT_MISMATCH")
+        if(call) {
+            property name: 'environments',
+                    type: 'java.util.List<java.lang.String>'
+            property name: 'pattern',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("POM_PLUGIN_ATTRIBUTE")
+        if(call) {
+            property name: 'groupId',
+                    type: 'java.lang.String'
+            property name: 'artifactId',
+                    type: 'java.lang.String'
+            property name: 'attributes',
+                    type: 'java.util.Map<java.lang.String, java.lang.String>'
+        }
+
+        call = enclosingCall("UNUSED_FLOW")
+        if(call) {
+        }
+
+        call = enclosingCall("FLOW_SUBFLOW_NAMING")
+        if(call) {
+            property name: 'format',
+                    type: 'com.avioconsulting.mule.linter.model.CaseNaming$CaseFormat'
+        }
+
+        call = enclosingCall("GIT_IGNORE")
+        if(call) {
+            property name: 'ignoredFiles',
+                    type: 'java.util.List<java.lang.String>'
+        }
+
+        call = enclosingCall("MULE_ARTIFACT_SECURE_PROPERTIES")
+        if(call) {
+            property name: 'properties',
+                    type: 'java.util.List<java.lang.String>'
+            property name: 'includeDefaults',
+                    type: 'java.lang.Boolean'
+        }
+
+        call = enclosingCall("DISPLAY_NAME")
+        if(call) {
+            property name: 'components',
+                    type: 'java.util.List'
+        }
+
+        call = enclosingCall("GLOBAL_CONFIG_NO_FLOWS")
+        if(call) {
+            property name: 'globalFileName',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("COMPONENT_COUNT")
+        if(call) {
+            property name: 'component',
+                    type: 'java.lang.String'
+            property name: 'namespace',
+                    type: 'java.lang.String'
+            property name: 'maxCount',
+                    type: 'java.lang.Integer'
+        }
+
+        call = enclosingCall("LOGGER_ATTRIBUTES_RULE")
+        if(call) {
+            property name: 'requiredAttributes',
+                    type: 'java.util.List<java.lang.String>'
+        }
+
+        call = enclosingCall("MULE_ARTIFACT_MIN_MULE_VERSION")
+        if(call) {
+        }
+
+        call = enclosingCall("COMMENTED_CODE")
+        if(call) {
+        }
+
+        call = enclosingCall("CONFIG_PLACEHOLDER")
+        if(call) {
+            property name: 'placeholderAttributes',
+                    type: 'java.lang.String[]'
+        }
+
+        call = enclosingCall("POM_EXISTS")
+        if(call) {
+        }
+
+        call = enclosingCall("ENCRYPTED_VALUE")
+        if(call) {
+        }
+
+        call = enclosingCall("MULE_CONFIG_SIZE")
+        if(call) {
+            property name: 'flowLimit',
+                    type: 'java.lang.Integer'
+        }
+
+        call = enclosingCall("PROPERTY_FILE_NAMING")
+        if(call) {
+            property name: 'environments',
+                    type: 'java.util.List<java.lang.String>'
+            property name: 'pattern',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("LOGGER_MESSAGE_CONTENTS")
+        if(call) {
+            property name: 'pattern',
+                    type: 'java.util.regex.Pattern'
+        }
+
+        call = enclosingCall("HOSTNAME_PROPERTY")
+        if(call) {
+            property name: 'exemptions',
+                    type: 'java.lang.String[]'
+        }
+
+        call = enclosingCall("README")
+        if(call) {
+        }
+
+        call = enclosingCall("ON_ERROR_LOG_EXCEPTION")
+        if(call) {
+        }
+
+        call = enclosingCall("API_CONSOLE_DISABLED")
+        if(call) {
+        }
+
+        call = enclosingCall("MAVEN_PROPERTY")
+        if(call) {
+            property name: 'propertyName',
+                    type: 'java.lang.String'
+            property name: 'propertyValue',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("AZURE_PIPELINES_EXISTS")
+        if(call) {
+        }
+
+        call = enclosingCall("JENKINS_EXISTS")
+        if(call) {
+        }
+
+        call = enclosingCall("COMPONENT_ATTRIBUTE_VALUE")
+        if(call) {
+            property name: 'component',
+                    type: 'java.lang.String'
+            property name: 'namespace',
+                    type: 'java.lang.String'
+            property name: 'attributeMatchers',
+                    type: 'java.util.Map<java.lang.String, java.util.regex.Pattern>'
+        }
+
+        call = enclosingCall("EXCESSIVE_LOGGERS")
+        if(call) {
+            property name: 'excessiveLoggers',
+                    type: 'java.lang.Integer'
+        }
+
+        call = enclosingCall("MUNIT_MAVEN_PLUGIN_ATTRIBUTES")
+        if(call) {
+            property name: 'coverageAttributeMap',
+                    type: 'java.util.Map<java.lang.String, java.lang.String>'
+            property name: 'includeDefaults',
+                    type: 'java.lang.Boolean'
+            property name: 'ignoreFiles',
+                    type: 'java.util.List<java.lang.String>'
+        }
+
+        call = enclosingCall("POM_DEPENDENCY_VERSION")
+        if(call) {
+            property name: 'groupId',
+                    type: 'java.lang.String'
+            property name: 'artifactId',
+                    type: 'java.lang.String'
+            property name: 'artifactVersion',
+                    type: 'java.lang.String'
+            property name: 'versionOperator',
+                    type: 'com.avioconsulting.mule.linter.model.Version$Operator'
+        }
+
+        call = enclosingCall("PROPERTY_EXISTS")
+        if(call) {
+            property name: 'propertyName',
+                    type: 'java.lang.String'
+            property name: 'environments',
+                    type: 'java.util.List<java.lang.String>'
+            property name: 'pattern',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("GLOBAL_CONFIG")
+        if(call) {
+            property name: 'globalFileName',
+                    type: 'java.lang.String'
+            property name: 'noneGlobalElements',
+                    type: 'java.util.Map<java.lang.String, java.lang.String>'
+        }
+
+        call = enclosingCall("MUNIT_PLUGIN_VERSION")
+        if(call) {
+            property name: 'version',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("MULE_MAVEN_PLUGIN")
+        if(call) {
+            property name: 'version',
+                    type: 'java.lang.String'
+        }
+
+        call = enclosingCall("UNTIL_SUCCESSFUL")
+        if(call) {
+        }
+
+        call = enclosingCall("LOGGER_CATEGORY_HASVALUE")
+        if(call) {
+        }
+
+        call = enclosingCall("LOGGER_MESSAGE_HASVALUE")
+        if(call) {
+        }
+
+        call = enclosingCall("MULE_RUNTIME")
+        if(call) {
+        }
+
+        call = enclosingCall("MUNIT_VERSION")
+        if(call) {
+            property name: 'version',
+                    type: 'java.lang.String'
+        }
+
+
+}


### PR DESCRIPTION
See build section in readme.

`./gradlew generateDSL` will regenerate `mule-linter-core/src/main/resources/mule-linter-core.dsl` populated for all Rules -

. Requires RULE_ID static variable on each rule.
. Parameters must be annotated with `@Param` to include in GDSL.