### PR TITLE
fix: violation count in log

### DIFF
--- a/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/formatter/impl/ConsoleFormatter.java
+++ b/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/formatter/impl/ConsoleFormatter.java
@@ -2,9 +2,12 @@ package com.avioconsulting.mule.maven.formatter.impl;
 
 
 import com.avioconsulting.mule.linter.model.rule.RuleSeverity;
+import com.avioconsulting.mule.linter.model.rule.RuleViolation;
 import org.apache.maven.plugin.logging.Log;
 
 import com.avioconsulting.mule.linter.model.rule.Rule;
+
+import java.util.List;
 
 /**
  * @author aivaldi
@@ -23,7 +26,8 @@ public class ConsoleFormatter extends AbstractFormatter {
         log.info( String.format("%s rules executed.", rulesCount));
         log.info("Rule validation results");
 
-        this.ruleExecutor.getResults().forEach( violation ->{
+        List<RuleViolation> violationList = this.ruleExecutor.getResults();
+        violationList.forEach(violation ->{
                     Rule rule = violation.getRule();
                     String ruleSeverity = rule.getSeverity().toString();
                     String ruleId = rule.getRuleId();
@@ -45,7 +49,7 @@ public class ConsoleFormatter extends AbstractFormatter {
                 }
         );
 
-        log.info( String.format("Found a total of %s violations of %s rules.", rulesCount,rulesCount));
+        log.info( String.format("Found a total of %s violations of %s rules.", violationList.size(),rulesCount));
 
         log.info( separator );
 


### PR DESCRIPTION
Fixes #84 - Wrong violation count in console formatter.

New result has correct violation count - 

```
[INFO] Found a total of 41 violations of 34 rules.
[INFO] ****************************************************************************
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.828 s
[INFO] Finished at: 2022-01-03T10:01:37-05:00
[INFO] ------------------------------------------------------------------------
```