### PR TITLE
Enabling Github Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<html>  
+<head>  
+<script type = "text/javascript">  
+function page_redirect() {  
+window.location = window.location.origin + "/mule-linter/groovydoc/index.html";  
+}  
+setTimeout('page_redirect()', 2000);  
+</script>  
+</head>  
+  
+<body>  
+<h2>Redirecting to groovydoc ...</h2>
+</body>  
+</html>  


### PR DESCRIPTION
Files to support using [Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) for groovydoc publishing.

In addition to these files, Github Pages needs to be manually enabled in [avioconsulting/mule-linter settings](https://github.com/avioconsulting/mule-linter/settings/pages).