### PR TITLE
Fix: SonarQube JSON export format is invalid

### DIFF
--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/model/rule/RuleExecutor.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/model/rule/RuleExecutor.groovy
@@ -63,8 +63,10 @@ class RuleExecutor {
                 this.primaryLocation = new SonarQubeReportLocation();
                 this.primaryLocation.filePath = violation.fileName
                 this.primaryLocation.message = violation.message
-                this.primaryLocation.textRange = new SonarQubeReportLocation.TextRange();
-                this.primaryLocation.textRange.startLine=violation.lineNumber
+                if (violation.lineNumber > 0) {
+                    this.primaryLocation.textRange = new SonarQubeReportLocation.TextRange();
+                    this.primaryLocation.textRange.startLine=violation.lineNumber
+                }
             }
 
 

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/ConfigFileNamingRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/ConfigFileNamingRule.groovy
@@ -25,6 +25,7 @@ class ConfigFileNamingRule extends Rule {
     @Param("format") String format
 
     ConfigFileNamingRule() {
+        super(RULE_ID, RULE_NAME)
         this.caseNaming = new CaseNaming(CaseNaming.CaseFormat.KEBAB_CASE)
     }
 

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/FlowSubflowNamingRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/configuration/FlowSubflowNamingRule.groovy
@@ -27,7 +27,8 @@ class FlowSubflowNamingRule extends Rule {
      */
     @Param("format") String format
 
-    FlowSubflowNamingRule(){
+    FlowSubflowNamingRule() {
+        super(RULE_ID, RULE_NAME)
         caseNaming = new CaseNaming(CaseNaming.CaseFormat.KEBAB_CASE)
     }
 

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/model/SonarQubeReportTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/model/SonarQubeReportTest.groovy
@@ -1,0 +1,36 @@
+package com.avioconsulting.mule.linter.model
+
+import com.avioconsulting.mule.linter.model.rule.Rule
+import com.avioconsulting.mule.linter.model.rule.RuleViolation
+import com.avioconsulting.mule.linter.model.rule.RuleExecutor.SonarQubeReport
+import spock.lang.Specification
+
+class SonarQubeReportTest extends Specification {
+
+    def 'check lineNumber reported correctly'() {
+        given:
+        SonarQubeReport sq = new SonarQubeReport();
+        DummyRule dummyRule = new DummyRule();
+        when:
+        RuleViolation violationZeroLine = new RuleViolation(dummyRule, 'testPath', 0, 'testViolation')
+        RuleViolation violationGreaterThanZeroLine = new RuleViolation(dummyRule, 'testPath', 11, 'testViolation')
+        sq.getIssues().add(new SonarQubeReport.SonarQubeReportIssues(violationZeroLine))
+        sq.getIssues().add(new SonarQubeReport.SonarQubeReportIssues(violationGreaterThanZeroLine))
+        then:
+        sq.getIssues()[0].primaryLocation.textRange == null 
+        sq.getIssues()[1].primaryLocation.textRange != null
+        sq.getIssues()[1].primaryLocation.textRange.startLine == 11
+    }
+}
+
+class DummyRule extends Rule {
+    static final String RULE_ID = 'DUMMY_RULE'
+    static final String RULE_NAME = 'Dummy Test Rule.'
+    @Override
+    List<RuleViolation> execute(Application app){
+        return null
+    }
+    DummyRule() {
+        super(RULE_ID, RULE_NAME)
+    }
+}


### PR DESCRIPTION
The format used for the JSON SonarQube export is considered invalid by SonarQube (version 9.6)
* ConfigFileNaming and FlowSubflowNaming rules didn't call the super constructor, causing the export to not include the engineId field which is required by the SonarQube importer
* The exporter was generating a textRange for rules reporting violations with line 0.  SonarQube importer requires the line number to be valid (> 0).