### PR TITLE
chore: publish to maven central with gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: ./gradlew publish
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
 
       - name: Tag Release
         if: ${{ !contains(steps.set-version.outputs.version, 'SNAPSHOT') && github.event_name != 'pull_request' && github.ref == 'refs/heads/master'}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 #        run: ./gradlew publish jreleaserFullRelease
 
       - name: Maven Deploy and Release
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,16 +44,25 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ./**/build/test-results/test/*.xml
 
+#      - name: Maven Deploy and Release
+#        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+#        env:
+#          JRELEASER_GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+#          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+#          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_GPG_PUBLIC_KEY }}
+#          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+#          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+#          JRELEASER_NEXUS2_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#        run: ./gradlew publish jreleaserFullRelease
+
       - name: Maven Deploy and Release
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        if: github.event_name != 'pull_request'
         env:
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          JRELEASER_NEXUS2_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        run: ./gradlew publish jreleaserFullRelease
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: ./gradlew publish
 
       - name: Tag Release
         if: ${{ !contains(steps.set-version.outputs.version, 'SNAPSHOT') && github.event_name != 'pull_request' && github.ref == 'refs/heads/master'}}

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,9 @@ subprojects {
     }
 
     signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.maven
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,24 @@ plugins {
     id 'base'
     id 'net.thauvin.erik.gradle.semver' version '1.0.4'
     id 'org.jreleaser' version '1.4.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
 jreleaser {
     configFile = 'jreleaser.yml'
 }
 
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
+}
+
 subprojects {
     apply plugin: 'groovy'
     apply plugin: 'java'
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
     apply plugin: 'net.thauvin.erik.gradle.semver'
 
     group 'com.avioconsulting.mule'
@@ -108,10 +116,14 @@ subprojects {
                 }
             }
         }
-        repositories {
-            maven {
-                url = layout.getBuildDirectory().dir("staging-deploy")
-            }
-        }
+//        repositories {
+//            maven {
+//                url = layout.getBuildDirectory().dir("staging-deploy")
+//            }
+//        }
+    }
+
+    signing {
+        sign publishing.publications.maven
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@
 plugins {
     id 'base'
     id 'net.thauvin.erik.gradle.semver' version '1.0.4'
-    id 'org.jreleaser' version '1.4.0'
+//    id 'org.jreleaser' version '1.4.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
-
-jreleaser {
-    configFile = 'jreleaser.yml'
-}
+//
+//jreleaser {
+//    configFile = 'jreleaser.yml'
+//}
 
 nexusPublishing {
     repositories {

--- a/version.properties
+++ b/version.properties
@@ -4,5 +4,5 @@ version.buildmeta=
 version.major=1
 version.minor=0
 version.patch=1
-version.prerelease=
-version.semver=1.0.1
+version.prerelease=SNAPSHOT
+version.semver=1.0.1-SNAPSHOT


### PR DESCRIPTION
Removing JReleaser until a sample project is published successfully. Using Gradle publishing configuration to publish artifacts to maven central.

1.0.1-SNAPSHOT was [published to Sonatype](https://oss.sonatype.org/#nexus-search;quick~mule-linter) during workflow testing.