### PR TITLE
chore: add codeowners team [skip ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+
+## Require review from one of the member from this team
+
+* @avioconsulting/avio-mulesoft-frameworks


### PR DESCRIPTION
Add `avioconsulting/avio-mulesoft-frameworks` as codeowner.