### PR TITLE
chore: set root group id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ plugins {
 //    configFile = 'jreleaser.yml'
 //}
 
+group 'com.avioconsulting.mule'
+
 nexusPublishing {
     repositories {
         sonatype()


### PR DESCRIPTION
Fix for actions failure:

```
Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to find staging profile for package group: 
```

Found the answer - https://github.com/gradle-nexus/publish-plugin/issues/150.

The root project is missing groupId.  The Issue also mentions requiring a version at the root project, but we are using a SemVer plugin. It should be fine not to declare explicitly. SemVer is applied before nexus publish.
