### PR TITLE
Moving from Groovy .length to Java .size()

### DIFF
--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/property/HostnamePropertyRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/property/HostnamePropertyRule.groovy
@@ -35,7 +35,7 @@ class HostnamePropertyRule extends Rule{
         application.propertyFiles.each { PropertyFile file ->
             file.getProperties().each {
                 String propName = it.key.toLowerCase()
-                if ((exemptions.length == 0 || !exemptions.any {propName.contains(it.toLowerCase())}) &&
+                if ((exemptions.size() == 0 || !exemptions.any {propName.contains(it.toLowerCase())}) &&
                         (propName.contains("host") || propName.contains("hostname"))) {
                     if (it.value.toString().trim() ==~ IPV4_REGEX || it.value.toString().trim() ==~ IPV6_REGEX) {
                         violations.add(new RuleViolation(this, file.getFile().path, 0,


### PR DESCRIPTION
A bug was detected when setting the exemptions array using the HOSTNAME_PROPERTY rule.

`HOSTNAME_PROPERTY {
            exemptions = ['api.http.host', 'api.https.host', 'api.http.private.host', 'api.https.private.host']
        }`
Running the above configuration gives the following error:

`Execution validate of goal com.avioconsulting.mule:mule-linter-maven-plugin:1.0.1:validate failed: Exception evaluating property 'length' for java.util.ArrayList, Reason: groovy.lang.MissingPropertyException: No such property: length for class: java.lang.String`

Switching to .size() alleviates this error.