### PR TITLE
feat: Added API Autodiscovery rule

### DIFF
--- a/docs/available_rules.md
+++ b/docs/available_rules.md
@@ -32,16 +32,18 @@ ApiConsoleDisabledRule()
 This rule takes no arguments. 
 
 ### AUTO_DISCOVERY_EXISTS
-
 This rule checks that every flow in the Mule application with HTTP listener component, should have an API Autodiscovery configuration for it where `flowRef` attribute matches the name of the flow with HTTP listener component.
 `apiId` property for the Autodiscovery configuration should be externalized into property files, and `apiId` should be unique for each environment, unless it is a set of defined values (-1, 0, 1) to be overwritten at deployment time.
-
+API Autodiscovery is critical Rule from API Security perspective. Without API Auto discovery configuration no security policy can be applied via API Manager.
 The constructor for this rule is:
 
 ```groovy
-AutoDiscoveryRule(List<String> environments)
-AutoDiscoveryRule(List<String> environments, String pattern)
+AutoDiscoveryRule(boolean enabled, List<String> exemptedFlows, List<String> environments, String pattern)
 ```
+*enabled* is a boolean flag to enable/disable API Autodiscovery rule, when set to `false` API Autodiscovery rule will be ignored. This is default to boolean value `true`.
+
+*exemptedFlows* is a list of flow names with HTTP listener component exempted for API AutoDiscovery. The default list is `[]`
+
 *environments* is a list of environments that the property must be found in.
 This value is used when determining the name for property files to be searched.
 The default list is:

--- a/mule-linter-core/AVIOGDSLRuleConfiguration.groovy
+++ b/mule-linter-core/AVIOGDSLRuleConfiguration.groovy
@@ -7,6 +7,8 @@ mule_linter {
     /* CONFIGURATION */
         API_CONSOLE_DISABLED{}
         AUTO_DISCOVERY_EXISTS {
+            enabled = true
+            exemptedFlows = []
             environments = ['dev', 'test', 'prod']
             pattern = '${appname}-${env}.properties'
         }


### PR DESCRIPTION
API Autodiscovery rule checks that every flow in the Mule application with HTTP listener component, should have an API Autodiscovery configuration for it where `flowRef` attribute matches the name of the flow with HTTP listener component. `apiId` property for the Autodiscovery configuration should be externalized into property files, and `apiId` should be unique for each environment, unless it is a set of defined values (-1, 0, 1) to be overwritten at deployment time.