### PR TITLE
feat: Added APIKIT_VERSION rule

### DIFF
--- a/docs/available_rules.md
+++ b/docs/available_rules.md
@@ -407,6 +407,18 @@ This rule takes no arguments.
 
 ## POM
 
+### APIKIT_VERSION
+
+This rule checks for the presence of a mule-apikit-module dependency with a given version in the `pom.xml`.
+
+The constructor for this rule is:
+
+```groovy
+ApikitVersionRule(String artifactVersion)
+```
+*artifactVersion* is the artifact version for `mule-apikit-module dependency` that is expected within the `pom.xml`.
+By default the artifactVersion is set to `1.9.0`.
+
 ### MULE_MAVEN_PLUGIN
 
 This rule ensures that the `mule-maven-plugin` of a specified version exists in the `pom.xml`.

--- a/mule-linter-core/AVIOGDSLRuleConfiguration.groovy
+++ b/mule-linter-core/AVIOGDSLRuleConfiguration.groovy
@@ -121,6 +121,9 @@ mule_linter {
         }
 
     /* PROPERTY */
+        APIKIT_VERSION {
+            artifactVersion = '1.9.0'
+        }
         ENCRYPTED_VALUE {}
         HOSTNAME_PROPERTY {
             exemptions = []

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/ApikitVersionRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/ApikitVersionRule.groovy
@@ -1,0 +1,39 @@
+package com.avioconsulting.mule.linter.rule.pom
+
+import com.avioconsulting.mule.linter.model.Application
+import com.avioconsulting.mule.linter.model.Version
+import com.avioconsulting.mule.linter.model.pom.PomDependency
+import com.avioconsulting.mule.linter.model.pom.PomElement
+import com.avioconsulting.mule.linter.model.rule.Param
+import com.avioconsulting.mule.linter.model.rule.Rule
+import com.avioconsulting.mule.linter.model.rule.RuleViolation
+
+class ApikitVersionRule extends PomDependencyVersionRule {
+    static final String RULE_ID = 'APIKIT_VERSION'
+    static final String RULE_NAME = 'The given Maven dependency exists in pom.xml and matches given version criteria. '
+
+    static final String GROUP_ID = 'org.mule.modules'
+    static final String ARTIFACT_ID = 'mule-apikit-module'
+    static final String ARTIFACT_VERSION = '1.9.0'
+    static final String VERSION_OPERATOR = Version.Operator.GREATER_THAN
+
+    /**
+     * artifactVersion: is the artifact version for the APIKit module in your artifact repository.
+     * This is currently default to 1.9.0, and can be overriden by passing in the rule.
+     */
+    @Param("artifactVersion") String artifactVersion
+
+    ApikitVersionRule(){
+        super(RULE_ID, RULE_NAME,GROUP_ID,ARTIFACT_ID,VERSION_OPERATOR)
+    }
+
+    @Override
+    void init(){
+        if(artifactVersion != null)
+            super.artifactVersion = artifactVersion
+        else
+            super.artifactVersion = ARTIFACT_VERSION
+        super.init()
+    }
+
+}

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRule.groovy
@@ -52,6 +52,13 @@ class PomDependencyVersionRule extends Rule {
         this.versionOperator = Version.Operator.EQUAL
     }
 
+    PomDependencyVersionRule(String ruleId, String ruleName, String groupId, String artifactId, String versionOperator){
+        super(ruleId, ruleName)
+        this.groupId = groupId
+        this.artifactId = artifactId
+        this.versionOperator = versionOperator
+        version= new Version()
+    }
     @Override
     void init(){
         try{

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/ApikitVersionRuleTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/ApikitVersionRuleTest.groovy
@@ -1,0 +1,146 @@
+package com.avioconsulting.mule.linter.rule.pom
+
+import com.avioconsulting.mule.linter.TestApplication
+import com.avioconsulting.mule.linter.model.MuleApplication
+import com.avioconsulting.mule.linter.model.pom.PomFile
+import com.avioconsulting.mule.linter.model.rule.Rule
+import com.avioconsulting.mule.linter.model.rule.RuleViolation
+import spock.lang.Specification
+
+class ApikitVersionRuleTest extends Specification {
+
+    private final TestApplication testApp = new TestApplication()
+    private MuleApplication app
+
+    def setup() {
+        testApp.initialize()
+    }
+
+    def cleanup() {
+        testApp.remove()
+    }
+
+    def 'Missing APIKit Maven Dependency'() {
+        given:
+        testApp.addFile(PomFile.POM_XML, MISSING_DEPENDENCY_POM)
+        Rule rule = new ApikitVersionRule()
+        rule.init()
+
+        when:
+        app = new MuleApplication(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        println(violations)
+        violations.size() == 1
+        violations[0].fileName.contains('pom.xml')
+        violations[0].message.startsWith(PomDependencyVersionRule.MISSING_DEPENDENCY)
+    }
+
+    def 'APIKit Maven Dependency version does not match'() {
+        given:
+        testApp.addFile(PomFile.POM_XML, WITH_DEPENDENCY_POM)
+
+        when:
+        Rule rule = new ApikitVersionRule()
+        rule.artifactVersion = '1.9.2'
+        rule.init()
+        app = new MuleApplication(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        println(violations)
+        violations.size() == 1
+        violations[0].fileName.contains('pom.xml')
+        violations[0].message.startsWith(PomDependencyVersionRule.RULE_VIOLATION_MESSAGE)
+    }
+
+    def 'Correct Equal Maven Dependency version for APIKit module'() {
+        given:
+        testApp.addFile(PomFile.POM_XML, WITH_DEPENDENCY_POM)
+        Rule rule = new ApikitVersionRule()
+        rule.init()
+
+        when:
+        app = new MuleApplication(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        violations.size() == 0
+    }
+
+    def 'Correct Version in Maven Property for APIKit Dependency'() {
+        given:
+        testApp.addFile(PomFile.POM_XML, DEPENDENCY_PROPERTY_VERSION_POM);
+        Rule rule = new ApikitVersionRule()
+        rule.artifactVersion = '1.8.0'
+        rule.init()
+
+        when:
+        app = new MuleApplication(testApp.appDir)
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        violations.size() == 0
+    }
+
+    private static final String MISSING_DEPENDENCY_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+\t\txmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+\t\txsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+\t\t\thttp://maven.apache.org/maven-v4_0_0.xsd">
+\t<modelVersion>4.0.0</modelVersion>
+\t<groupId>com.avioconsulting.mulelinter</groupId>
+\t<artifactId>sample-mule-app</artifactId>
+\t<version>1.0.0</version>
+\t<packaging>mule-application</packaging>
+\t<name>sample-mule-app-sys-api</name>
+</project>
+'''
+
+    private static final String WITH_DEPENDENCY_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+\t\txmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+\t\txsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+\t\t\thttp://maven.apache.org/maven-v4_0_0.xsd">
+\t<modelVersion>4.0.0</modelVersion>
+\t<groupId>com.avioconsulting.mulelinter</groupId>
+\t<artifactId>sample-mule-app</artifactId>
+\t<version>1.0.0</version>
+\t<packaging>mule-application</packaging>
+\t<name>sample-mule-app-sys-api</name>
+\t<dependencies>
+\t\t<dependency>
+\t\t\t<groupId>org.mule.modules</groupId>
+\t\t\t<artifactId>mule-apikit-module</artifactId>
+\t\t\t<version>1.9.1</version>
+\t\t\t<classifier>mule-plugin</classifier>
+\t\t</dependency>
+\t</dependencies>
+</project>
+'''
+    private static final String DEPENDENCY_PROPERTY_VERSION_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+\t\txmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+\t\txsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+\t\t\thttp://maven.apache.org/maven-v4_0_0.xsd">
+\t<modelVersion>4.0.0</modelVersion>
+\t<groupId>com.avioconsulting.mulelinter</groupId>
+\t<artifactId>sample-mule-app</artifactId>
+\t<version>1.0.0</version>
+\t<packaging>mule-application</packaging>
+\t<name>sample-mule-app-sys-api</name>
+\t<properties>
+\t\t<apikit-version>1.8.2</apikit-version>
+\t</properties>
+\t<dependencies>
+\t\t<dependency>
+\t\t\t<groupId>org.mule.modules</groupId>
+\t\t\t<artifactId>mule-apikit-module</artifactId>
+\t\t\t<version>${apikit-version}</version>
+\t\t\t<classifier>mule-plugin</classifier>
+\t\t</dependency>
+\t</dependencies>
+</project>
+'''
+}


### PR DESCRIPTION
There is a memory leak issue in APIKit versions <= 1.3.11 (https://help.mulesoft.com/s/article/Out-Of-Memory-Metaspace-while-often-re-deploying-applications-using-APIKit).

This rule is implemented to check that the version of APIKit dependency in pom.xml is at least _artifactVersion_ passed in the rule.

_artifactVersion_ for APIKIT_VERSION rule is defaulted to **'1.9.0'**.