### PR TITLE
chore(build): deploy core rules documentation to github pages

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -39,6 +39,8 @@ jobs:
           distribution: adopt-hotspot
           java-version: 8
           cache: gradle
+      - name: Compile
+        run: ./gradlew assemble
       - name: Verify
         # build to generate docs folder
         run: ./gradlew check

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           distribution: adopt-hotspot
           java-version: 8
-          cache: maven
+          cache: gradle
       - name: Verify
         # build to generate docs folder
-        run: ./mvnw --batch-mode verify
+        run: ./gradlew check
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -6,7 +6,7 @@ on:
   # Temporary on current branch
   push:
     branches:
-      - master
+      - main
       - feat/**
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -32,15 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
-          distribution: adopt-hotspot
-          java-version: 8
-          cache: gradle
-      - name: Compile
-        run: ./gradlew assemble
+          java-version: 1.8
+
+      - name: Set Version
+        id: set-version
+        run: "./gradlew properties -q | grep version: | awk '{print \"::set-output name=version::\" $2}'"
+
+      - name: Print Version
+        run: echo "Version ${{ steps.set-version.outputs.version }}"
+
       - name: Verify
         # build to generate docs folder
         run: ./gradlew check

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - feat/**
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -33,17 +33,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
-      - name: Set Version
-        id: set-version
-        run: "./gradlew properties -q | grep version: | awk '{print \"::set-output name=version::\" $2}'"
-
-      - name: Print Version
-        run: echo "Version ${{ steps.set-version.outputs.version }}"
 
       - name: Verify
         # build to generate docs folder

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -1,0 +1,54 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  # Temporary on current branch
+  push:
+    branches:
+      - master
+      - feat/**
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt-hotspot
+          java-version: 8
+          cache: maven
+      - name: Verify
+        # build to generate docs folder
+        run: ./mvnw --batch-mode verify
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: './mule-linter-core/build/docs/groovydoc'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   # Single deploy job since we're just deploying
-  deploy:
+  deploy-pages:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -35,7 +35,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.8
 
@@ -43,12 +43,12 @@ jobs:
         # build to generate docs folder
         run: ./gradlew check
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
           path: './mule-linter-core/build/docs/groovydoc'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Mule Linter core is shipped with [many rules](https://github.com/avioconsulting/mule-linter/tree/main/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule). When building the module, groovy docs are generated under ./mule-linter-core/build/docs. It will be helpful to publish these to github pages for reference.

This will resolve the issue with [github pages] deploy action (https://github.com/avioconsulting/mule-linter/issues/133)