### PR TITLE
Updates base POM rules to use pom.xml as filename when reporting validation errors

### DIFF
--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRule.groovy
@@ -5,6 +5,7 @@ import com.avioconsulting.mule.linter.model.CaseNaming
 import com.avioconsulting.mule.linter.model.Version
 import com.avioconsulting.mule.linter.model.pom.PomDependency
 import com.avioconsulting.mule.linter.model.pom.PomElement
+import com.avioconsulting.mule.linter.model.pom.PomFile
 import com.avioconsulting.mule.linter.model.rule.Param
 import com.avioconsulting.mule.linter.model.rule.Rule
 import com.avioconsulting.mule.linter.model.rule.RuleViolation
@@ -76,7 +77,7 @@ class PomDependencyVersionRule extends Rule {
         PomDependency dependency = app.pomFile.getDependency(groupId, artifactId)
 
         if ( dependency == null ) {
-            violations.add(new RuleViolation(this, app.pomFile.path, 0, MISSING_DEPENDENCY + "$groupId , $artifactId"))
+            violations.add(new RuleViolation(this, PomFile.POM_XML, 0, MISSING_DEPENDENCY + "$groupId , $artifactId"))
         } else {
             Boolean isViolated = false;
             PomElement attribute = dependency.getAttribute('version')
@@ -89,7 +90,7 @@ class PomDependencyVersionRule extends Rule {
                     isViolated = (!version.isGreater(dependencyVersion)) ? true : false
             }
             if (isViolated) {
-                violations.add(new RuleViolation(this, app.pomFile.path, 0,
+                violations.add(new RuleViolation(this, PomFile.POM_XML, 0,
                         RULE_VIOLATION_MESSAGE + "$groupId , $artifactId, $attribute.value"))
             }
         }

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomPluginAttributeRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomPluginAttributeRule.groovy
@@ -2,6 +2,7 @@ package com.avioconsulting.mule.linter.rule.pom
 
 import com.avioconsulting.mule.linter.model.Application
 import com.avioconsulting.mule.linter.model.pom.PomElement
+import com.avioconsulting.mule.linter.model.pom.PomFile
 import com.avioconsulting.mule.linter.model.pom.PomPlugin
 import com.avioconsulting.mule.linter.model.rule.Param
 import com.avioconsulting.mule.linter.model.rule.Rule
@@ -53,12 +54,12 @@ class PomPluginAttributeRule extends Rule {
         PomPlugin plugin = app.pomFile.getPlugin(groupId, artifactId)
 
         if ( plugin == null ) {
-            violations.add(new RuleViolation(this, app.pomFile.path, 0, MISSING_PLUGIN + "$groupId , $artifactId"))
+            violations.add(new RuleViolation(this, PomFile.POM_XML, 0, MISSING_PLUGIN + "$groupId , $artifactId"))
         } else {
             attributes.each {
                 PomElement attribute = plugin.getAttribute(it.key)
                 if ( attribute.value != it.value) {
-                    violations.add(new RuleViolation(this, app.pomFile.path, 0,
+                    violations.add(new RuleViolation(this, PomFile.POM_XML, 0,
                             RULE_VIOLATION_MESSAGE + "$it.key : $it.value"))
                 }
             }

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomPropertyValueRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/pom/PomPropertyValueRule.groovy
@@ -2,6 +2,7 @@ package com.avioconsulting.mule.linter.rule.pom
 
 import com.avioconsulting.mule.linter.model.Application
 import com.avioconsulting.mule.linter.model.pom.PomElement
+import com.avioconsulting.mule.linter.model.pom.PomFile
 import com.avioconsulting.mule.linter.model.rule.Param
 import com.avioconsulting.mule.linter.model.rule.Rule
 import com.avioconsulting.mule.linter.model.rule.RuleViolation
@@ -43,12 +44,12 @@ class PomPropertyValueRule extends Rule {
         try {
             PomElement pomProperty = app.pomFile.getPomProperty(propertyName)
             if (!pomProperty.value.equalsIgnoreCase(propertyValue)) {
-                violations.add(new RuleViolation(this, app.pomFile.path,
+                violations.add(new RuleViolation(this, PomFile.POM_XML,
                         0, pomProperty.name + RULE_VIOLATION_MESSAGE + 'Expected: ' + propertyValue
                         + ' found: ' + pomProperty.value))
             }
         } catch (IllegalArgumentException e) {
-            violations.add(new RuleViolation(this, app.pomFile.path,
+            violations.add(new RuleViolation(this, PomFile.POM_XML,
                     0, propertyName + ATTRIBUTE_MISSING_MESSAGE))
         }
 

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/property/EncryptedPasswordRule.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/rule/property/EncryptedPasswordRule.groovy
@@ -13,8 +13,8 @@ import com.avioconsulting.mule.linter.model.rule.RuleViolation
 class EncryptedPasswordRule extends Rule {
 
     static final String RULE_ID = 'ENCRYPTED_VALUE'
-    static final String RULE_NAME = 'The Property File contains ‘secret’ or ‘password’ values that are encrypted. '
-    static final String RULE_VIOLATION_MESSAGE = 'The Property file contains a ‘secret’ or ‘password’ that is not encrypted: '
+    static final String RULE_NAME = 'The Property File contains `secret` or `password` values that are encrypted. '
+    static final String RULE_VIOLATION_MESSAGE = 'The Property file contains a `secret` or `password` that is not encrypted: '
     static final String ENC_REGEX = '(\\!\\[.*?\\])'
 
     EncryptedPasswordRule() {

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomArtifactAttributeRuleTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomArtifactAttributeRuleTest.groovy
@@ -36,6 +36,7 @@ class PomArtifactAttributeRuleTest extends Specification {
         then:
         violations.size() == 1
         violations[0].message.startsWith(PomPluginAttributeRule.MISSING_PLUGIN)
+        violations[0].fileName == PomFile.POM_XML
     }
 
     def 'Correct Maven Plugin version'() {
@@ -71,6 +72,7 @@ class PomArtifactAttributeRuleTest extends Specification {
         then:
         violations.size() == 1
         violations[0].message.startsWith(PomPluginAttributeRule.RULE_VIOLATION_MESSAGE)
+        violations[0].fileName == PomFile.POM_XML
     }
 
     def 'Correct Maven Plugin version check as property'() {
@@ -106,6 +108,7 @@ class PomArtifactAttributeRuleTest extends Specification {
         then:
         violations.size() == 1
         violations[0].message.startsWith(PomPluginAttributeRule.RULE_VIOLATION_MESSAGE)
+        violations[0].fileName == PomFile.POM_XML
     }
 
     private static final String MISSING_PLUGINS_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRuleTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRuleTest.groovy
@@ -37,6 +37,7 @@ class PomDependencyVersionRuleTest extends Specification {
         then:
         violations.size() == 1
         violations[0].message.startsWith(PomDependencyVersionRule.MISSING_DEPENDENCY)
+        violations[0].fileName == PomFile.POM_XML
     }
 
     def 'Correct Equal Maven Dependency version'() {
@@ -74,6 +75,7 @@ class PomDependencyVersionRuleTest extends Specification {
         then:
         violations.size() == 1
         violations[0].message.startsWith(PomDependencyVersionRule.RULE_VIOLATION_MESSAGE)
+        violations[0].fileName == PomFile.POM_XML
     }
 
     def 'Multiple Greater Than Maven Dependency version'() {
@@ -93,6 +95,10 @@ class PomDependencyVersionRuleTest extends Specification {
 
         then:
         violations.size() == size
+        if (violations.size() == 1) {
+            violations[0].fileName == PomFile.POM_XML
+        }
+
 
         where:
         version | size

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomPropertyValueRuleTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomPropertyValueRuleTest.groovy
@@ -1,6 +1,7 @@
 package com.avioconsulting.mule.linter.rule.pom
 
 import com.avioconsulting.mule.linter.model.MuleApplication
+import com.avioconsulting.mule.linter.model.pom.PomFile
 import com.avioconsulting.mule.linter.model.rule.Rule
 import com.avioconsulting.mule.linter.model.rule.RuleViolation
 import com.avioconsulting.mule.linter.TestApplication
@@ -44,6 +45,7 @@ class PomPropertyValueRuleTest extends  Specification {
         then:
         violations.size() == 1
         violations[0].message  == 'munit.version maven property value does not match expected value. Expected: 3.2.1 found: 2.2.1'
+        violations[0].fileName == PomFile.POM_XML
     }
 
     def 'Missing Property'() {
@@ -56,6 +58,7 @@ class PomPropertyValueRuleTest extends  Specification {
         then:
         violations.size() == 1
         violations[0].message == 'invalid.munit.version does not exist in <properties></properties>'
+        violations[0].fileName == PomFile.POM_XML
     }
 
 }


### PR DESCRIPTION
With the feature to support parent POM by evaluating the effective pom, the base POM rules where reporting validation errors on the effective pom file instead of the pom.xml.
This would cause Sonarqube to ignore these errors, as they are reported on a file that does not exist in the code base.

fixes avioconsulting/mule-linter#168