### PR TITLE
Feature/Support Maven Profiles

### DIFF
--- a/mule-linter-cli/src/main/groovy/com/avioconsulting/mule/linter/MuleLinterCli.groovy
+++ b/mule-linter-cli/src/main/groovy/com/avioconsulting/mule/linter/MuleLinterCli.groovy
@@ -19,13 +19,17 @@ class MuleLinterCli implements Runnable {
     @CommandLine.Option(names = ['-f', '--format'], defaultValue = 'CONSOLE',
             description = 'Report Output Format. Valid values: ${COMPLETION-CANDIDATES}')
     ReportFormat outputFormat
+
+    @CommandLine.Option(names = ['-p', '--profiles'], arity = '0..*', description = 'List of Maven profiles to apply', split = ',')
+    List<String> profiles
+
     static void main(String... args) {
         new CommandLine(new MuleLinterCli()).execute(args)
     }
 
     @Override
     void run() {
-        MuleLinter ml = new MuleLinter(appDir, ruleConfiguration, outputFormat)
+        MuleLinter ml = new MuleLinter(appDir, ruleConfiguration, outputFormat, profiles)
         ml.runLinter()
     }
 

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/MuleLinter.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/MuleLinter.groovy
@@ -18,8 +18,8 @@ class MuleLinter {
     List<RuleSet> ruleSetList = []
     ReportFormat  outputFormat
 
-    MuleLinter(File applicationDirectory, File ruleConfigFile, ReportFormat outputFormat) {
-        this.app = new MuleApplication(applicationDirectory)
+    MuleLinter(File applicationDirectory, File ruleConfigFile, ReportFormat outputFormat, List<String> profiles = null) {
+        this.app = new MuleApplication(applicationDirectory, profiles)
         //ruleSetList = parseConfigurationFile(ruleConfigFile)
         ruleSetList = processDSL(ruleConfigFile)
         this.outputFormat= outputFormat

--- a/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/model/MuleApplication.groovy
+++ b/mule-linter-core/src/main/groovy/com/avioconsulting/mule/linter/model/MuleApplication.groovy
@@ -30,7 +30,7 @@ class MuleApplication implements Application {
     GitIgnoreFile gitignoreFile
     MuleArtifact muleArtifact
 
-    MuleApplication(File applicationPath) {
+    MuleApplication(File applicationPath, List<String> profiles = null) {
         this.applicationPath = applicationPath
         if (!this.applicationPath.exists()) {
             throw new FileNotFoundException( APPLICATION_DOES_NOT_EXIST + applicationPath.absolutePath)
@@ -38,7 +38,7 @@ class MuleApplication implements Application {
         File pFile = new File(applicationPath, POM_FILE)
         // if pom.xml exists in application, get the effective-pom.xml for the application.
         if (pFile.exists())
-            pFile = getEffectivePomFile(pFile)
+            pFile = getEffectivePomFile(pFile, profiles)
         pomFile = new PomFile(pFile, pFile.exists() ? new MuleXmlParser().parse(pFile) : null)
         gitignoreFile = new GitIgnoreFile(applicationPath, GITIGNORE_FILE)
         readmeFile = new ReadmeFile(applicationPath, README)
@@ -57,7 +57,7 @@ class MuleApplication implements Application {
      * 2. Set MAVEN_HOME environment variable in the system executing mule-linter.
      * returns File
      */
-    File getEffectivePomFile(File pFile){
+    File getEffectivePomFile(File pFile, List<String> profiles = null){
         def mavenHome = null
         // Update mavenHome from system property - maven.home
         if (System.getProperty('maven.home') != null)
@@ -74,6 +74,7 @@ class MuleApplication implements Application {
             setGoals([mvnGoals])
             setPomFile(pFile)
             setShowErrors(true)
+            setProfiles(profiles)
             it
         }
         def mavenInvoker = new DefaultInvoker()

--- a/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRuleTest.groovy
+++ b/mule-linter-core/src/test/groovy/com/avioconsulting/mule/linter/rule/pom/PomDependencyVersionRuleTest.groovy
@@ -127,6 +127,24 @@ class PomDependencyVersionRuleTest extends Specification {
         violations.size() == 0
     }
 
+    def 'Correct Version With Maven Profile'() {
+        given:
+        testApp.addFile(PomFile.POM_XML, DEPENDENCY_PROFILE_PROPERTY_VERSION_POM);
+        Rule rule = new PomDependencyVersionRule()
+        rule.groupId = 'org.mule.connectors'
+        rule.artifactId = 'mule-http-connector'
+        rule.artifactVersion = '2.9.5'
+        rule.versionOperator = 'EQUAL'
+        rule.init()
+
+        when:
+        app = new MuleApplication(testApp.appDir, ['testProfile'])
+        List<RuleViolation> violations = rule.execute(app)
+
+        then:
+        violations.size() == 0
+    }    
+
     private static final String MISSING_DEPENDENCY_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -220,6 +238,62 @@ class PomDependencyVersionRuleTest extends Specification {
     <version>1.0.0</version>
     <packaging>mule-application</packaging>
     <name>sample-mule-app-sys-api</name>
+    <properties>
+        <app.runtime>4.2.1</app.runtime>
+        <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>
+        <http.connector.version>1.3.2</http.connector.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.mule.tools.maven</groupId>
+                <artifactId>mule-maven-plugin</artifactId>
+                <version>${mule.maven.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <classifier>mule-application</classifier>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.mule.connectors</groupId>
+            <artifactId>mule-http-connector</artifactId>
+            <version>${http.connector.version}</version>
+            <classifier>mule-plugin</classifier>
+        </dependency>
+    </dependencies>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>mulesoft-releases</id>
+            <name>mulesoft release repository</name>
+            <layout>default</layout>
+            <url>https://repository.mulesoft.org/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+</project>
+'''
+
+    private static final String DEPENDENCY_PROFILE_PROPERTY_VERSION_POM = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.avioconsulting.mulelinter</groupId>
+    <artifactId>sample-mule-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>mule-application</packaging>
+    <name>sample-mule-app-sys-api</name>
+    <profiles>
+        <profile>
+            <id>testProfile</id>
+            <properties>
+                <http.connector.version>2.9.5</http.connector.version>
+            </properties>
+        </profile>
+    </profiles>
     <properties>
         <app.runtime>4.2.1</app.runtime>
         <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>

--- a/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/mojo/AbstractMuleLinterMojo.java
+++ b/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/mojo/AbstractMuleLinterMojo.java
@@ -8,6 +8,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class AbstractMuleLinterMojo extends AbstractMojo {
 
@@ -29,6 +30,13 @@ public abstract class AbstractMuleLinterMojo extends AbstractMojo {
     public String getProjectVersion (){
         return this.project.getVersion();
     }
+
+    public List<String> getProjectInjectedProfileIds (){
+        return this.project.getInjectedProfileIds().values().stream()
+            .flatMap(List::stream)
+            .distinct()
+            .collect(Collectors.toList());
+    }    
 
     public void failIfNeeded(boolean shouldFail, List<RuleViolation> violations){
         if(shouldFail && !violations.isEmpty()

--- a/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/mojo/MuleLinterValidateMojo.java
+++ b/mule-linter-maven-plugin/src/main/java/com/avioconsulting/mule/maven/mojo/MuleLinterValidateMojo.java
@@ -35,7 +35,8 @@ public class MuleLinterValidateMojo extends AbstractMuleLinterMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        MuleLinter muleLinter = new MuleLinter(appDir, ruleConfiguration, ReportFormat.valueOf(FormatOptionsEnum.CONSOLE.name().toUpperCase()));
+        MuleLinter muleLinter = new MuleLinter(appDir, ruleConfiguration, ReportFormat.valueOf(FormatOptionsEnum.CONSOLE.name().toUpperCase()), 
+        this.getProjectInjectedProfileIds());
         this.getLog().debug(format("Executing linter config %s against application %s", ruleConfiguration.getAbsolutePath(), appDir.getAbsolutePath()));
         RuleExecutor ruleExecutor = muleLinter.buildLinterExecutor();
         try {


### PR DESCRIPTION
# Add Maven Profile Support for Effective POM Resolution

Resolves #178 

## Changes

This PR adds support for Maven profiles by retrieving them with the Maven plugin. It also allows users to specify active profiles via CLI parameter.
This helps to detect correct dependencies that can be changed with profiles.

### Added

- Adds support to obtain active profiles with the Maven plugin and pass them to the Groovy core.
- Adds support the CLI to receive a list of comma separated profiles to pass to the Groovy core.